### PR TITLE
Modification in destructuring: variable changed

### DIFF
--- a/server/controllers/fs.js
+++ b/server/controllers/fs.js
@@ -5,11 +5,11 @@ module.exports = ({ strapi }) => ({
   getOne: async (ctx, next) => {
 
     try {
-      const { name } = ctx.params;
+      const { folderName } = ctx.params;
       const folder = await strapi.query("plugin::upload.folder").findOne({
         where: {
           name: {
-            $eqi: name,
+            $eqi: folderName,
           },
         },
         populate: ["files", "children"],


### PR DESCRIPTION
In this pull request, I performed an update on the destructuring of an object, specifically name to folderName. This modification allows that when consulting the path docs/:folderName it does not return the 404 error when not finding the folder.

Greetings